### PR TITLE
make master work with 11.2

### DIFF
--- a/email-encryption-demo/.classpath
+++ b/email-encryption-demo/.classpath
@@ -5,12 +5,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**/*.ivyClass|**/*.p.json|**/*.rddescriptor|**/*.xhtml" kind="src" path="src_hd">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src_wsproc">
+		<classpathentry kind="src" path="src_wsproc">
 		<attributes>
 			<attribute name="optional" value="true"/>
 		</attributes>

--- a/email-encryption-demo/.settings/ch.ivyteam.ivy.designer.prefs
+++ b/email-encryption-demo/.settings/ch.ivyteam.ivy.designer.prefs
@@ -1,5 +1,5 @@
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_DATA_CLASS=com.axonivy.utils.email.encryption.demo.Data
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_NAMESPACE=com.axonivy.utils.email.encryption.demo
 ch.ivyteam.ivy.project.preferences\:PRIMEFACES_VERSION=11
-ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=100000
+ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=112000
 eclipse.preferences.version=1

--- a/email-encryption-demo/.settings/org.eclipse.wst.common.component
+++ b/email-encryption-demo/.settings/org.eclipse.wst.common.component
@@ -2,7 +2,6 @@
     <wb-module deploy-name="email-encryption-demo">
         <wb-resource deploy-path="/" source-path="/webContent" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src"/>
-        <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_hd"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_wsproc"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_dataClasses"/>
         <property name="context-root" value="email-encryption-demo"/>

--- a/email-encryption-demo/pom.xml
+++ b/email-encryption-demo/pom.xml
@@ -6,6 +6,15 @@
   <artifactId>email-encryption-demo</artifactId>
   <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.utils.email.encryption</groupId>
@@ -19,7 +28,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>11.2.0-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/email-encryption-demo/pom.xml
+++ b/email-encryption-demo/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.email.encryption</groupId>
   <artifactId>email-encryption-demo</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
     <dependency>

--- a/email-encryption-demo/processes/Demo/SendEncryptedEmail.p.json
+++ b/email-encryption-demo/processes/Demo/SendEncryptedEmail.p.json
@@ -1,5 +1,5 @@
 {
-  "format" : "10.0.0",
+  "$schema" : "https://json-schema.axonivy.com/process/11.2.1/process.json",
   "id" : "18442CF71BAC8A4F",
   "config" : {
     "data" : "com.axonivy.utils.email.encryption.demo.SendEncryptedEmailData"
@@ -9,15 +9,20 @@
       "type" : "RequestStart",
       "name" : "start.ivp",
       "config" : {
-        "callSignature" : "start",
-        "outLink" : "start.ivp",
-        "startName" : "Send Encrypted Email",
-        "tags" : "demo"
+        "signature" : "start",
+        "request" : {
+          "name" : "Send Encrypted Email"
+        }
       },
+      "tags" : [
+        "demo"
+      ],
       "visual" : {
         "at" : { "x" : 96, "y" : 64 }
       },
-      "connect" : { "id" : "f4", "to" : "f3" }
+      "connect" : [
+        { "id" : "f4", "to" : "f3" }
+      ]
     }, {
       "id" : "f1",
       "type" : "TaskEnd",
@@ -29,12 +34,13 @@
       "type" : "DialogCall",
       "name" : "EmailDialog",
       "config" : {
-        "dialogId" : "com.axonivy.utils.email.encryption.demo.EmailDialog",
-        "startMethod" : "start()"
+        "dialog" : "com.axonivy.utils.email.encryption.demo.EmailDialog:start()"
       },
       "visual" : {
         "at" : { "x" : 224, "y" : 64 }
       },
-      "connect" : { "id" : "f2", "to" : "f1" }
+      "connect" : [
+        { "id" : "f2", "to" : "f1" }
+      ]
     } ]
 }

--- a/email-encryption-demo/src_hd/com/axonivy/utils/email/encryption/demo/EmailDialog/EmailDialogProcess.p.json
+++ b/email-encryption-demo/src_hd/com/axonivy/utils/email/encryption/demo/EmailDialog/EmailDialogProcess.p.json
@@ -1,5 +1,5 @@
 {
-  "format" : "10.0.0",
+  "$schema" : "https://json-schema.axonivy.com/process/11.2.1/process.json",
   "id" : "1844329E5F6F0023",
   "kind" : "HTML_DIALOG",
   "config" : {
@@ -10,13 +10,15 @@
       "type" : "HtmlDialogStart",
       "name" : "start()",
       "config" : {
-        "callSignature" : "start",
+        "signature" : "start",
         "guid" : "1844329E5FEFE4FC"
       },
       "visual" : {
         "at" : { "x" : 96, "y" : 64 }
       },
-      "connect" : { "id" : "f7", "to" : "f6" }
+      "connect" : [
+        { "id" : "f7", "to" : "f6" }
+      ]
     }, {
       "id" : "f1",
       "type" : "HtmlDialogEnd",
@@ -33,7 +35,9 @@
       "visual" : {
         "at" : { "x" : 96, "y" : 160 }
       },
-      "connect" : { "id" : "f5", "to" : "f4" }
+      "connect" : [
+        { "id" : "f5", "to" : "f4" }
+      ]
     }, {
       "id" : "f4",
       "type" : "HtmlDialogExit",
@@ -57,6 +61,8 @@
       "visual" : {
         "at" : { "x" : 224, "y" : 64 }
       },
-      "connect" : { "id" : "f2", "to" : "f1" }
+      "connect" : [
+        { "id" : "f2", "to" : "f1" }
+      ]
     } ]
 }

--- a/email-encryption-product/pom.xml
+++ b/email-encryption-product/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.email.encryption</groupId>
   <artifactId>email-encryption-product</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/email-encryption-test/.classpath
+++ b/email-encryption-test/.classpath
@@ -5,12 +5,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**/*.ivyClass|**/*.p.json|**/*.rddescriptor|**/*.xhtml" kind="src" path="src_hd">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src_wsproc">
+		<classpathentry kind="src" path="src_wsproc">
 		<attributes>
 			<attribute name="optional" value="true"/>
 		</attributes>

--- a/email-encryption-test/.settings/ch.ivyteam.ivy.designer.prefs
+++ b/email-encryption-test/.settings/ch.ivyteam.ivy.designer.prefs
@@ -1,5 +1,5 @@
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_DATA_CLASS=com.axonivy.utils.test.Data
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_NAMESPACE=com.axonivy.utils.test
 ch.ivyteam.ivy.project.preferences\:PRIMEFACES_VERSION=11
-ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=100000
+ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=112000
 eclipse.preferences.version=1

--- a/email-encryption-test/.settings/org.eclipse.wst.common.component
+++ b/email-encryption-test/.settings/org.eclipse.wst.common.component
@@ -2,7 +2,6 @@
     <wb-module deploy-name="email-encryption-test">
         <wb-resource deploy-path="/" source-path="/webContent" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src"/>
-        <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_hd"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_wsproc"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_dataClasses"/>
         <property name="context-root" value="email-encryption-test"/>

--- a/email-encryption-test/pom.xml
+++ b/email-encryption-test/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.email.encryption</groupId>
   <artifactId>email-encryption-test</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
   <dependencies>
     <dependency>

--- a/email-encryption-test/pom.xml
+++ b/email-encryption-test/pom.xml
@@ -6,6 +6,28 @@
   <artifactId>email-encryption-test</artifactId>
   <version>11.2.0-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
+  <properties>
+    <project.build.plugin.version>11.2.0-SNAPSHOT</project.build.plugin.version>
+    <webtester.version>11.2.0-SNAPSHOT</webtester.version>
+  </properties>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.utils.email.encryption</groupId>
@@ -16,7 +38,7 @@
     <dependency>
       <groupId>com.axonivy.ivy.webtest</groupId>
       <artifactId>web-tester</artifactId>
-      <version>10.0.0</version>
+      <version>${webtester.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -26,7 +48,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/email-encryption/.classpath
+++ b/email-encryption/.classpath
@@ -5,12 +5,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**/*.ivyClass|**/*.p.json|**/*.rddescriptor|**/*.xhtml" kind="src" path="src_hd">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src_wsproc">
+		<classpathentry kind="src" path="src_wsproc">
 		<attributes>
 			<attribute name="optional" value="true"/>
 		</attributes>

--- a/email-encryption/.settings/ch.ivyteam.ivy.designer.prefs
+++ b/email-encryption/.settings/ch.ivyteam.ivy.designer.prefs
@@ -1,5 +1,5 @@
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_DATA_CLASS=com.axonivy.utils.email.encryption.Data
 ch.ivyteam.ivy.designer.preferences.DataClassPreferencePage\:DEFAULT_NAMESPACE=com.axonivy.utils.email.encryption
 ch.ivyteam.ivy.project.preferences\:PRIMEFACES_VERSION=11
-ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=100000
+ch.ivyteam.ivy.project.preferences\:PROJECT_VERSION=112000
 eclipse.preferences.version=1

--- a/email-encryption/.settings/org.eclipse.wst.common.component
+++ b/email-encryption/.settings/org.eclipse.wst.common.component
@@ -2,7 +2,6 @@
     <wb-module deploy-name="email-encryption">
         <wb-resource deploy-path="/" source-path="/webContent" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src"/>
-        <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_hd"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_wsproc"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src_dataClasses"/>
         <property name="context-root" value="email-encryption"/>

--- a/email-encryption/pom.xml
+++ b/email-encryption/pom.xml
@@ -6,6 +6,15 @@
   <artifactId>email-encryption</artifactId>
   <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -23,7 +32,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>11.2.0-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/email-encryption/pom.xml
+++ b/email-encryption/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.email.encryption</groupId>
   <artifactId>email-encryption</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
     <dependency>

--- a/email-encryption/src/com/axonivy/utils/email/encryption/service/EncryptedEmailSender.java
+++ b/email-encryption/src/com/axonivy/utils/email/encryption/service/EncryptedEmailSender.java
@@ -20,7 +20,6 @@ import org.bouncycastle.cms.jcajce.JceKeyTransRecipientInfoGenerator;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.mail.smime.SMIMEEnvelopedGenerator;
 import org.bouncycastle.operator.OutputEncryptor;
-import org.eclipse.core.resources.IProject;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -31,7 +30,6 @@ import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.mail.MailClientConfig;
 import ch.ivyteam.ivy.mail.MailClientConfigProvider;
 import ch.ivyteam.ivy.mail.MailConstants.EmailEncryption;
-import ch.ivyteam.ivy.project.IIvyProject;
 import ch.ivyteam.ivy.scripting.objects.File;
 import ch.ivyteam.ivy.security.exec.Sudo;
 
@@ -136,9 +134,7 @@ public class EncryptedEmailSender {
 		return Sudo.call(new Callable<MailClientConfig>() {
 			@Override
 			public MailClientConfig call() throws Exception {
-				IProject project = Ivy.request().getProcessModelVersion().getProject();
-				IIvyProject ivyProject = (IIvyProject) project.getAdapter(IIvyProject.class);
-				return MailClientConfigProvider.get(ivyProject);
+				return MailClientConfigProvider.get();
 			}
 		});
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.utils.email.encryption</groupId>
   <name>email-encryption</name>
   <artifactId>email-encryption-modules</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Hi @majeed-hm 
this repo was no longer compatiable with 11.2 ... so I splitted the development:
- master = latest release (yet 11.2)
- release/10.0 = the lts release that most market users will work with.

... if new features are request, they should be on master ... and maybe backported to the release/10.0 version